### PR TITLE
Move /usr/local/bin/sync_mirror.sh creation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,11 +63,6 @@ class pulpcore_api (
   }
 
   if $deb_apt_mirrors {
-    ensure_resource ( 'file', '/usr/local/bin/sync_mirror.sh', {
-      ensure  => 'present',
-      content => epp("${module_name}/sync_mirror.sh.epp", {'pulp_server' => $pulp_server}),
-      mode    => '0755',
-    })
     create_resources(pulpcore_api::mirror::deb, $deb_apt_mirrors, $deb_apt_mirror_defaults)
   }
 

--- a/manifests/mirror/deb.pp
+++ b/manifests/mirror/deb.pp
@@ -19,6 +19,7 @@ define pulpcore_api::mirror::deb (
   Hash                  $repository_extra_options   = {},
   Hash                  $distribution_extra_options = {},
 ) {
+
   # Create remote
   pulpcore_deb_apt_remote { "mirror-${name}":
     ensure         => $ensure,
@@ -47,6 +48,12 @@ define pulpcore_api::mirror::deb (
     *          => $distribution_extra_options,
   }
 
+  ensure_resource ( 'file', '/usr/local/bin/sync_mirror.sh', {
+    ensure  => 'present',
+    content => epp("${module_name}/sync_mirror.sh.epp", {'pulp_server' => $::pulpcore_api::pulp_server}),
+    mode    => '0755',
+  })
+
   $_sync_template = @(EOT)
 <%- | $remote_href, $repository_href, $distribution_href | -%>
 #!/bin/bash
@@ -62,6 +69,7 @@ define pulpcore_api::mirror::deb (
     ensure  => 'present',
     content => Deferred('inline_epp', [$_sync_template, $_sync_config]),
     mode    => '0755',
+    require => File['/usr/local/bin/sync_mirror.sh'],
   }
 
   if $manage_timer {
@@ -75,6 +83,7 @@ define pulpcore_api::mirror::deb (
         'name'   => $name,
         'plugin' => 'deb'
       }),
+      require         => File["/usr/local/bin/sync_deb_mirror_${name}"],
     }
 
     service { "sync-mirror-${name}.timer":


### PR DESCRIPTION
Move to `pulpcore_api::mirror::deb`, so it still gets created when directly calling `pulpcore_api::mirror::deb` instead of defining mirrors through `pulpcore_api::deb_apt_mirrors`.

Also added some `require`'s