### PR TITLE
Add options to manage configs

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -22,8 +22,6 @@ pulpcore_api::agent_gems:
 pulpcore_api::resources: ~
 pulpcore_api::container_container_mirrors: ~
 pulpcore_api::container_container_mirror_defaults: {}
-pulpcore_api::file_file_mirrors: ~
-pulpcore_api::file_file_mirror_defaults: {}
 pulpcore_api::deb_apt_mirrors: ~
 pulpcore_api::deb_apt_mirror_defaults: {}
 pulpcore_api::file_file_mirrors: ~

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,8 @@
 ---
 pulpcore_api::pulp_server: "http://%{facts.networking.fqdn}"
+pulpcore_api::pulp_username: admin
+pulpcore_api::pulp_password: admin
+pulpcore_api::ssl_verify: true
 pulpcore_api::manage_agent_gems: true
 pulpcore_api::agent_gems:
   pulpcore_client:
@@ -12,6 +15,7 @@ pulpcore_api::agent_gems:
     version: 1.9.0
   pulp_rpm_client:
     version: 3.15.0
+pulpcore_api::manage_api_config: true
 pulpcore_api::resources: ~
 pulpcore_api::container_container_mirrors: ~
 pulpcore_api::container_container_mirror_defaults: {}

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -5,6 +5,7 @@ pulpcore_api::pulp_password: admin
 pulpcore_api::ssl_verify: true
 pulpcore_api::manage_api_config: true
 pulpcore_api::manage_cli_config: true
+pulpcore_api::manage_netrc: true
 pulpcore_api::cli_package: ~
 pulpcore_api::cli_package_ensure: installed
 pulpcore_api::manage_agent_gems: true

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,6 +3,10 @@ pulpcore_api::pulp_server: "http://%{facts.networking.fqdn}"
 pulpcore_api::pulp_username: admin
 pulpcore_api::pulp_password: admin
 pulpcore_api::ssl_verify: true
+pulpcore_api::manage_api_config: true
+pulpcore_api::manage_cli_config: true
+pulpcore_api::cli_package: ~
+pulpcore_api::cli_package_ensure: installed
 pulpcore_api::manage_agent_gems: true
 pulpcore_api::agent_gems:
   pulpcore_client:
@@ -15,7 +19,6 @@ pulpcore_api::agent_gems:
     version: 1.9.0
   pulp_rpm_client:
     version: 3.15.0
-pulpcore_api::manage_api_config: true
 pulpcore_api::resources: ~
 pulpcore_api::container_container_mirrors: ~
 pulpcore_api::container_container_mirror_defaults: {}

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -7,7 +7,7 @@ class pulpcore_api::configs (
   Boolean $manage_api_config = $::pulpcore_api::manage_api_config,
   Boolean $manage_cli_config = $::pulpcore_api::manage_cli_config,
   Boolean $manage_netrc = $::pulpcore_api::manage_netrc,
-  String $cli_package = $::pulpcore_api::cli_package,
+  Optional[String] $cli_package = $::pulpcore_api::cli_package,
   String $cli_package_ensure = $::pulpcore_api::cli_package_ensure,
 ) {
 

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -6,6 +6,7 @@ class pulpcore_api::configs (
   Boolean $ssl_verify = $::pulpcore_api::ssl_verify,
   Boolean $manage_api_config = $::pulpcore_api::manage_api_config,
   Boolean $manage_cli_config = $::pulpcore_api::manage_cli_config,
+  Boolean $manage_netrc = $::pulpcore_api::manage_netrc,
   String $cli_package = $::pulpcore_api::cli_package,
   String $cli_package_ensure = $::pulpcore_api::cli_package_ensure,
 ) {
@@ -20,6 +21,7 @@ class pulpcore_api::configs (
         scheme     => $scheme,
         ssl_verify => $ssl_verify,
       }),
+      mode    => '0640',
     }
   }
 
@@ -52,7 +54,26 @@ class pulpcore_api::configs (
     file{ '/root/.config/pulp/cli.toml':
       ensure  => file,
       content => $cli_config,
+      mode    => '0640',
       require => Exec['mkdir-root-config-pulp'],
+    }
+
+  }
+
+
+  if $manage_netrc {
+
+    $netrc = @("NETRC")
+      # This file is managed by puppet - DO NOT EDIT
+      machine ${pulp_host}
+      login ${pulp_username}
+      password ${pulp_password}
+      | NETRC
+
+    file{ '/root/.netrc':
+      ensure  => file,
+      content => $netrc,
+      mode    => '0640',
     }
 
   }

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -1,0 +1,60 @@
+class pulpcore_api::configs (
+  String $pulp_host = split($::pulpcore_api::pulp_server, '://')[1],
+  String $pulp_username = $::pulpcore_api::pulp_username,
+  String $pulp_password = $::pulpcore_api::pulp_password,
+  Enum['http', 'https'] $scheme = split($::pulpcore_api::pulp_server, '://')[0],
+  Boolean $ssl_verify = $::pulpcore_api::ssl_verify,
+  Boolean $manage_api_config = $::pulpcore_api::manage_api_config,
+  Boolean $manage_cli_config = $::pulpcore_api::manage_cli_config,
+  String $cli_package = $::pulpcore_api::cli_package,
+  String $cli_package_ensure = $::pulpcore_api::cli_package_ensure,
+) {
+
+  if $manage_api_config {
+    file{ '/etc/puppetlabs/puppet/pulpcoreapi.yaml':
+      ensure  => file,
+      content => to_yaml({
+        host       => $pulp_host,
+        username   => $pulp_username,
+        password   => $pulp_password,
+        scheme     => $scheme,
+        ssl_verify => $ssl_verify,
+      }),
+    }
+  }
+
+  if $cli_package {
+    package{ $cli_package:
+      ensure => $cli_package_ensure,
+    }
+  }
+
+
+  if $manage_cli_config {
+
+    exec{ 'mkdir-root-config-pulp':
+      command => '/bin/mkdir -p /root/.config/pulp',
+      creates => '/root/.config/pulp',
+    }
+
+    $cli_config = @("CLI_CONFIG")
+      # This file is managed by puppet - DO NOT EDIT
+      [cli]
+      base_url = "${scheme}://${pulp_host}"
+      username = "${pulp_username}"
+      password = "${pulp_password}"
+      verify_ssl = ${ssl_verify}
+      format = "json"
+      dry_run = false
+      timeout = 0
+      | CLI_CONFIG
+
+    file{ '/root/.config/pulp/cli.toml':
+      ensure  => file,
+      content => $cli_config,
+      require => Exec['mkdir-root-config-pulp'],
+    }
+
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,10 @@
 #
 class pulpcore_api (
   String                      $pulp_server,
+  Boolean                     $manage_api_config,
+  String                      $pulp_username,
+  String                      $pulp_password,
+  Boolean                     $ssl_verify,
   Boolean                     $manage_agent_gems,
   Hash[String,Hash]           $agent_gems,
   Optional[Hash[String,Hash]] $resources,
@@ -49,6 +53,19 @@ class pulpcore_api (
         ensure   => $options['version'],
         provider => 'puppet_gem',
       }
+    }
+  }
+
+  if $manage_api_config {
+    file{ '/etc/puppetlabs/puppet/pulpcoreapi.yaml':
+      ensure  => file,
+      content => to_yaml({
+        scheme     => split($pulp_server, '://')[0],
+        host       => split($pulp_server, '://')[1],
+        username   => $pulp_username,
+        password   => $pulp_password,
+        ssl_verify => $ssl_verify,
+      }),
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class pulpcore_api (
   Boolean                     $ssl_verify,
   Boolean                     $manage_api_config,
   Boolean                     $manage_cli_config,
+  Boolean                     $manage_netrc,
   Optional[String]            $cli_package,
   String                      $cli_package_ensure,
   Boolean                     $manage_agent_gems,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,10 +26,13 @@
 #
 class pulpcore_api (
   String                      $pulp_server,
-  Boolean                     $manage_api_config,
   String                      $pulp_username,
   String                      $pulp_password,
   Boolean                     $ssl_verify,
+  Boolean                     $manage_api_config,
+  Boolean                     $manage_cli_config,
+  Optional[String]            $cli_package,
+  String                      $cli_package_ensure,
   Boolean                     $manage_agent_gems,
   Hash[String,Hash]           $agent_gems,
   Optional[Hash[String,Hash]] $resources,
@@ -56,18 +59,7 @@ class pulpcore_api (
     }
   }
 
-  if $manage_api_config {
-    file{ '/etc/puppetlabs/puppet/pulpcoreapi.yaml':
-      ensure  => file,
-      content => to_yaml({
-        scheme     => split($pulp_server, '://')[0],
-        host       => split($pulp_server, '://')[1],
-        username   => $pulp_username,
-        password   => $pulp_password,
-        ssl_verify => $ssl_verify,
-      }),
-    }
-  }
+  include pulpcore_api::configs
 
   if $resources {
     $resources.each |String $resource_type, Hash $instances| {


### PR DESCRIPTION
Since this module depends on some config files to be present on the system, it kinda makes sense that the module also has options to manage said config files.

Options:
* manage `/etc/puppetlabs/puppet/pulpcoreapi.yaml` (enabled by default)
* manage `/root/.config/pulp/cli.toml`(enabled by default)
* install cli package (undef by default)
* manage `/root/.netrc` (enabled by default)

Could disable these options by default if it is preferred to not cause potential duplicate resource declarations with existing code bases that already make use of this module.