### PR TITLE
add support for sync_policy on rpm mirrors

### DIFF
--- a/manifests/mirror/rpm.pp
+++ b/manifests/mirror/rpm.pp
@@ -10,7 +10,7 @@ define pulpcore_api::mirror::rpm (
   String                        $policy                     = 'immediate',
   Boolean                       $manage_timer               = true,
   String                        $timer_on_calendar          = 'daily',
-  Boolean                       $mirror                     = true,
+  Boolean                       $mirror                     = false,
   Pulpcore_api::Rpm_sync_policy $sync_policy                = 'additive',
   Hash                          $remote_extra_options       = {},
   Hash                          $repository_extra_options   = {},

--- a/manifests/mirror/rpm.pp
+++ b/manifests/mirror/rpm.pp
@@ -2,20 +2,21 @@
 #
 #
 define pulpcore_api::mirror::rpm (
-  Stdlib::HTTPUrl       $url,
-  String                $base_path,
-  String                $name_prefix                = 'rpm-mirror-',
-  String                $base_path_prefix           = 'rpm/pub/mirrors/',
-  Enum[present, absent] $ensure                     = 'present',
-  String                $policy                     = 'immediate',
-  Boolean               $manage_timer               = true,
-  String                $timer_on_calendar          = 'daily',
-  Boolean               $mirror                     = true,
-  Hash                  $remote_extra_options       = {},
-  Hash                  $repository_extra_options   = {},
-  Hash                  $distribution_extra_options = {},
-  Hash                  $pulp_labels                = {},
-  Hash                  $pulp_labels_defaults       = { 'type' => 'mirror' },
+  Stdlib::HTTPUrl               $url,
+  String                        $base_path,
+  String                        $name_prefix                = 'rpm-mirror-',
+  String                        $base_path_prefix           = 'rpm/pub/mirrors/',
+  Enum[present, absent]         $ensure                     = 'present',
+  String                        $policy                     = 'immediate',
+  Boolean                       $manage_timer               = true,
+  String                        $timer_on_calendar          = 'daily',
+  Boolean                       $mirror                     = true,
+  Pulpcore_api::Rpm_sync_policy $sync_policy                = 'additive',
+  Hash                          $remote_extra_options       = {},
+  Hash                          $repository_extra_options   = {},
+  Hash                          $distribution_extra_options = {},
+  Hash                          $pulp_labels                = {},
+  Hash                          $pulp_labels_defaults       = { 'type' => 'mirror' },
 ) {
   # Create remote
   pulpcore_rpm_rpm_remote { "${name_prefix}${name}":
@@ -52,9 +53,10 @@ define pulpcore_api::mirror::rpm (
         'on_calendar' => $timer_on_calendar,
       }),
       service_content => epp("${module_name}/mirror/service.epp", {
-        'name'   => "${name_prefix}${name}",
-        'plugin' => 'rpm',
-        'mirror' => $mirror,
+        'name'        => "${name_prefix}${name}",
+        'plugin'      => 'rpm',
+        'mirror'      => $mirror,
+        'sync_policy' => $sync_policy,
       }),
     }
 

--- a/templates/mirror/service.epp
+++ b/templates/mirror/service.epp
@@ -1,6 +1,7 @@
 <%- | String $name,
       String $plugin,
       Boolean $mirror = false,
+      Optional[String] $sync_policy = undef,
 | -%>
 # File managed by puppet (pulpcore_api)
 # Manual changes will be overwritten
@@ -11,4 +12,4 @@ RefuseManualStop=yes
 
 [Service]
 Type=oneshot
-ExecStart=/bin/pulp <%= $plugin %> repository sync --name <%= $name %> --remote <%= $name %> <%- if $mirror { %> --mirror <%- } -%>
+ExecStart=/bin/pulp <%= $plugin %> repository sync --name <%= $name %> --remote <%= $name %> <%- if $mirror { %> --mirror <%- } -%> <%- if $sync_policy { %> --sync-policy <%= $sync_policy %> <%- } -%>

--- a/types/rpm_sync_policy.pp
+++ b/types/rpm_sync_policy.pp
@@ -1,0 +1,6 @@
+# Valid RPM sync policies
+type Pulpcore_api::Rpm_sync_policy = Enum[
+  'additive',
+  'mirror_complete',
+  'mirror_content_only',
+]


### PR DESCRIPTION
rpm mirrors deprecated `mirror` option in favor of `sync_policy` option